### PR TITLE
Added feature for dark/light mode toggle

### DIFF
--- a/header.php
+++ b/header.php
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -7,4 +8,11 @@
     <title>RealTIme Chat App</title>
     <link rel="stylesheet" href="style.css?ver=0.2">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.2/css/all.min.css">
+    <link href="https://cdn.jsdelivr.net/npm/remixicon@3.5.0/fonts/remixicon.css" rel="stylesheet">
+    <link rel="stylesheet" href="style.css">
+    <script src="js/theme.js" defer></script>
+    <button class="theme-toggle" onclick="toggleTheme()">
+        <i id="theme-icon" class="ri-moon-line"></i>
+    </button>
+
 </head>

--- a/index.php
+++ b/index.php
@@ -5,6 +5,9 @@ if(isset($_SESSION['unique_id'])){
 }
 include_once "header.php";
 ?>
+
+
+
 <body>
     <div class="wrapper">
     <section class="form signup">

--- a/js/theme.js
+++ b/js/theme.js
@@ -1,0 +1,18 @@
+function toggleTheme() {
+  document.body.classList.toggle('dark-mode');
+  const icon = document.getElementById('theme-icon');
+  const isDark = document.body.classList.contains('dark-mode');
+  icon.className = isDark ? 'ri-moon-line' : 'ri-sun-line';
+  localStorage.setItem('theme', isDark ? 'dark' : 'light');
+}
+
+window.addEventListener('DOMContentLoaded', () => {
+  const isDark = localStorage.getItem('theme') === 'dark';
+  const icon = document.getElementById('theme-icon');
+  if (isDark) {
+    document.body.classList.add('dark-mode');
+    icon.className = 'ri-moon-line';
+  } else {
+    icon.className = 'ri-sun-line';
+  }
+});

--- a/style.css
+++ b/style.css
@@ -429,3 +429,93 @@ form .name-details .field:first-child{
     font-size: 16px;
     cursor: pointer;
 }
+
+
+:root {
+  --bg-color: #ffffff;
+  --text-color: #000000;
+  --box-bg: #ffffff;
+  --box-text: #000000;
+  --input-bg: #ffffff;
+  --input-text: #000000;
+  --button-bg: #333333;
+  --button-text: #ffffff;
+}
+
+body {
+  background-color: var(--bg-color);
+  color: var(--text-color);
+  transition: background-color 0.3s, color 0.3s;
+}
+
+body.dark-mode {
+  --bg-color: #121212;
+  --text-color: #ffffff;
+  --box-bg: #1e1e1e;
+  --box-text: #ffffff;
+  --input-bg: #2a2a2a;
+  --input-text: #ffffff;
+  --button-bg: #ffffff;
+  --button-text: #000000;
+}
+
+/* Toggle Button */
+.theme-toggle {
+  position: fixed;
+  top: 15px;
+  right: 20px;
+  background: none;
+  border: none;
+  font-size: 28px;
+  cursor: pointer;
+  color: var(--text-color);
+  z-index: 9999;
+}
+
+@media (max-width: 600px) {
+  .theme-toggle {
+    top: 10px;
+    right: 15px;
+    font-size: 24px;
+  }
+}
+
+/* Wrapper box */
+.wrapper {
+  background-color: var(--box-bg);
+  color: var(--box-text);
+  border-radius: 15px;
+  padding: 20px;
+  box-shadow: 0 4px 10px rgba(0,0,0,0.2);
+}
+
+/* Inputs and Textareas */
+.wrapper input,
+.wrapper select,
+.wrapper textarea {
+  background-color: var(--input-bg);
+  color: var(--input-text);
+  border: 1px solid #ccc;
+  padding: 10px;
+  width: 100%;
+  border-radius: 5px;
+  margin-top: 5px;
+}
+
+/* Placeholder color (optional for better look) */
+.wrapper input::placeholder,
+.wrapper textarea::placeholder {
+  color: #888;
+}
+
+/* Buttons */
+.wrapper button {
+  background-color: var(--button-bg);
+  color: var(--button-text);
+  border: none;
+  padding: 12px;
+  width: 100%;
+  border-radius: 5px;
+  margin-top: 10px;
+  cursor: pointer;
+}


### PR DESCRIPTION
Implemented a dark mode toggle for the chat app.

Added a responsive toggle button in the top-right corner using Remix Icon.

Updated CSS variables to smoothly switch between light and dark themes.

Ensured text, background, and button colors adapt correctly in both modes.

